### PR TITLE
Added React state functionality and New Board form

### DIFF
--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -26,3 +26,22 @@
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
+
+/* Dashboard CSS */
+div#new-board-form {
+  border-radius: .3rem;
+  padding: 24px;
+  position: absolute;
+  background: #fffbb8;
+  width: 90%;
+}
+
+.close-button {
+  position: absolute;
+  right: 3%;
+  top: 3%;
+  font-size: 1rem;
+  cursor: pointer;
+  border: 0;
+  background: 0;
+}

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -1,39 +1,13 @@
 import React, { Component } from 'react';
-import './App.css';
-//import '../public/vendor/bootstrap/css/bootstrap.min.css'
 import { Switch, Route, Link } from 'react-router-dom'
+import { Dashboard, BoardTile } from './Dashboard.js'
+import './App.css';
+
+
 
 const Board = () => (
 	<div>
 		<h2>Boards</h2>
-	</div>
-)
-
-const Dashboard = () => (
-	<div class="container">
-		<h3 class="mt-5 mb-4"><i class="fa fa-user-o mr-2" aria-hidden="true"></i> Personal Boards</h3>
-		<div class="row" id="personal-boards">
-			<div class="col-3">
-				<button class="btn btn-primary btn-block btn-lg mb-5 project-btn">Hello</button>
-			</div>
-			<div class="col-3">
-				<div id="new-board-modal">
-					<button type="button" class="close" aria-label="Close">
-						<span aria-hidden="true">&times;</span>
-					</button>
-					<p><strong>Create a New Board</strong></p>
-					<form>
-						<div class="form-group">
-							<label for="new-board-name">New Board Name</label>
-							<input type="text" id="new-board-name" class="mb-3 form-control" placeholder="Board name"/>
-							<small id="new-board-name-info" class="form-text text-muted">You can change this later on.</small>
-						</div>
-						<button type="button" class="btn btn-secondary" id="create-board-btn">Create Board</button>
-					</form>
-				</div>
-				<button class="btn btn-secondary btn-block btn-lg mb-5 project-btn" id="new-board-btn">Create New Board</button>
-			</div>
-		</div>
 	</div>
 )
 
@@ -93,5 +67,3 @@ const App = () => (
 )
 
 export default App;
-
-

--- a/my-app/src/Dashboard.js
+++ b/my-app/src/Dashboard.js
@@ -1,8 +1,5 @@
 import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
 
-
-// or Board-Preview
 class BoardTile extends Component {
 	render() {
 		return(
@@ -13,6 +10,7 @@ class BoardTile extends Component {
 	}
 }
 
+// This is the button to create a new board; only used once
 class NewBoardTile extends Component {
 	constructor(props) {
 		super(props);
@@ -21,13 +19,12 @@ class NewBoardTile extends Component {
 	}
 
 	onSubmit = (boardName) => {
-		//console.log("My new board name will be: ", boardName);
 		this.props.onSubmit(boardName);
 	};
 
 	toggleForm() {
 		this.setState({
-			isOpen: !this.state.isOpen
+			isOpen: !this.state.isOpen // When called, flips the state value (true->false)
 		});
 	}
 
@@ -47,17 +44,17 @@ class NewBoardForm extends Component {
 		this.onSubmit = this.onSubmit.bind(this);
 	}
 
-	state = {	boardName: '' }
+	state = { boardName: '' }
 
 	componentDidMount() {
 		this.newFormInput.focus();
 	}
 
 	onSubmit = (e) => {
-		e.preventDefault();
-		this.setState({ boardName: '' })
-		this.props.onSubmit(this.state.boardName);
-		this.props.onClose();	//when submitting the form, this calls the "onClose" prop method of "NewBoardTile.toggleform()"
+		e.preventDefault(); // prevents default action of reloading the page on form submit
+		this.setState({ boardName: '' }) // clears the form input field
+		this.props.onSubmit(this.state.boardName); // calls prop onSubmit function, passing it the value in the input field
+		this.props.onClose();	// when submitting the form, this calls the "onClose" prop method of "NewBoardTile.toggleform()"
 	}
 
 	render() {
@@ -88,18 +85,15 @@ class NewBoardForm extends Component {
 class Dashboard extends Component {
 	constructor(props) {
 		super(props);
-		// this.state = {formOpen: false};
-		// this.state = {newBoard: false};
-		// this.state = {newBoardName: ''};
 		this.state = {
 			formOpen: false,
 			newBoard: false,
-			newBoardNames: {}
+			newBoardName: ''
 		}
 	}
 
 	onNewBoardSubmit = (boardName) => {
-		console.log("GOT IT: ", boardName);
+		console.log("Received BoardName:", boardName);
 		this.setState({ newBoardName: boardName, newBoard: true });
 	}
 

--- a/my-app/src/Dashboard.js
+++ b/my-app/src/Dashboard.js
@@ -1,0 +1,120 @@
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+
+
+// or Board-Preview
+class BoardTile extends Component {
+	render() {
+		return(
+			<div class="col-12 col-sm-6 col-lg-3">
+				<button class="btn btn-primary btn-block btn-lg mb-5 project-btn">{this.props.name}</button>
+			</div>
+		)
+	}
+}
+
+class NewBoardTile extends Component {
+	constructor(props) {
+		super(props);
+		this.state = {isOpen: false};
+		this.onSubmit = this.onSubmit.bind(this);
+	}
+
+	onSubmit = (boardName) => {
+		//console.log("My new board name will be: ", boardName);
+		this.props.onSubmit(boardName);
+	};
+
+	toggleForm() {
+		this.setState({
+			isOpen: !this.state.isOpen
+		});
+	}
+
+	render() {
+		return(
+			<div class="col-12 col-sm-6 col-lg-3">
+				{this.state.isOpen && <NewBoardForm show={this.state.isOpen} onClose={this.toggleForm.bind(this)} onSubmit={boardName => { this.onSubmit(boardName) }} />}
+				<button class="btn btn-secondary btn-block btn-lg mb-5 project-btn" id="new-board-btn" onClick={this.toggleForm.bind(this)}>Create New Board</button>
+			</div>
+		)
+	}
+}
+
+class NewBoardForm extends Component {
+	constructor(props) {
+		super(props);
+		this.onSubmit = this.onSubmit.bind(this);
+	}
+
+	state = {	boardName: '' }
+
+	componentDidMount() {
+		this.newFormInput.focus();
+	}
+
+	onSubmit = (e) => {
+		e.preventDefault();
+		this.setState({ boardName: '' })
+		this.props.onSubmit(this.state.boardName);
+		this.props.onClose();	//when submitting the form, this calls the "onClose" prop method of "NewBoardTile.toggleform()"
+	}
+
+	render() {
+		if(!this.props.show) {
+			return null;
+		}
+
+		return(
+			<div id="new-board-form" class="col-12">
+				<button class="close-button" onClick={this.props.onClose.bind(this)}>&times;</button>
+				<form>
+					<h5 style={{borderBottom: "1px solid black", display: "inline-block"}}>Create A New Board</h5>
+					<p>Use this simple form to create a new board. You can always change the name and other settings later.</p>
+					<div class="form-group">
+						<label htmlFor="new-board-name">New Board Name:</label>
+						<input type="text" class="form-control" value={this.state.boardName}
+							onChange={e => this.setState({ boardName: e.target.value}) }
+							ref={input => { this.newFormInput = input }} id="new-board-name" placeholder="Name Your Board" />
+					</div>
+					<button onClick={e => this.onSubmit(e)} class="btn btn-primary">Create Board</button>
+				</form>
+			</div>
+		)
+	}
+}
+
+
+class Dashboard extends Component {
+	constructor(props) {
+		super(props);
+		// this.state = {formOpen: false};
+		// this.state = {newBoard: false};
+		// this.state = {newBoardName: ''};
+		this.state = {
+			formOpen: false,
+			newBoard: false,
+			newBoardNames: {}
+		}
+	}
+
+	onNewBoardSubmit = (boardName) => {
+		console.log("GOT IT: ", boardName);
+		this.setState({ newBoardName: boardName, newBoard: true });
+	}
+
+	render() {
+		return(
+			<div class="container">
+				<h3 class="mt-5 mb-4"><i class="fa fa-user-o mr-2" aria-hidden="true"></i> Personal Boards</h3>
+				<div class="row" id="personal-boards">
+					<BoardTile name="My First Board"/>
+					{this.state.newBoard && <BoardTile name={this.state.newBoardName} />}
+					<NewBoardTile onSubmit={boardName => { this.onNewBoardSubmit(boardName) }}/>
+				</div>
+			</div>
+		)
+	}
+}
+
+export { BoardTile, Dashboard };


### PR DESCRIPTION
This adds some state functionality to the "dashboard" page. The end goal of this is to be able to dynamically create new boards (front-end only, so far) on the dashboard page, using the "create new board" button and a corresponding form. 

The functionality is not yet complete, but the page will load and some features are implemented.  

Current features: 
1. Click on new board.
2. Type a board name into the form.
3. Hit enter key or press "Create Board"
4. A new board tile should appear with the name you typed, and the form should close.

This new board tile will disappear on refresh (its not saved anywhere). Currently you cannot add more than one new board tile, it will simply overwrite the first one. This will be the next problem to solve. 

Note: commented code will come soon. 